### PR TITLE
Bump version for 1.4.7 release

### DIFF
--- a/TheMessengerTrackPack/manifest.json
+++ b/TheMessengerTrackPack/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "The Messenger Randomizer Track Pack",
   "game_name": "The Messenger",
-  "package_version": "1.4.6",
+  "package_version": "1.4.7",
   "package_uid": "messenger_track_pack",
   "author": "alwaysintreble",
   "variants": {


### PR DESCRIPTION
poptracker complains about a version mismatch (1.4.6 != 1.4.7) without this change